### PR TITLE
Increase default txn gas.

### DIFF
--- a/stests/chain/constants.py
+++ b/stests/chain/constants.py
@@ -5,7 +5,7 @@ DEFAULT_TX_TIME_TO_LIVE = "3600000ms"
 DEFAULT_TX_GAS_PRICE = 10
 
 # Default transaction fee to apply.
-DEFAULT_TX_FEE = int(1e10)
+DEFAULT_TX_FEE = int(1e11)
 
 # Default transaction fee for native transfers.
 DEFAULT_TX_FEE_NATIVE_TRANSFER = int(1e4)


### PR DESCRIPTION
Recently, a cost of purse creation has increased and the default txn fee is not enough to pay for the execution.